### PR TITLE
feat: enable undo/redo in TimeInput

### DIFF
--- a/src/content/components/TimeInput.tsx
+++ b/src/content/components/TimeInput.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { formatTime, parseTime } from '../lib/time';
-import type { ChangeEvent } from 'react';
+import { useState, useEffect } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import type { Timestamp } from '../../lib/types';
 
 type Props = {
@@ -9,6 +10,32 @@ type Props = {
 };
 
 export function TimeInput({ time, onChange }: Props) {
+  const [history, setHistory] = useState<string[]>([]);
+  const [currentIndex, setCurrentIndex] = useState<number>(-1);
+
+  function handleUndo() {
+    if (currentIndex > 0) {
+      setCurrentIndex((prevIndex) => prevIndex - 1);
+      onChange(history[currentIndex - 1]);
+    }
+  }
+
+  function handleRedo() {
+    if (currentIndex < history.length - 1) {
+      setCurrentIndex((prevIndex) => prevIndex + 1);
+      onChange(history[currentIndex + 1]);
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.ctrlKey && e.key === 'z') {
+      handleUndo();
+    }
+    if (e.ctrlKey && e.shiftKey && e.key === 'Z') {
+      handleRedo();
+    }
+  }
+
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
     const value = e.currentTarget.value;
     onChange(value);
@@ -27,13 +54,18 @@ export function TimeInput({ time, onChange }: Props) {
     onChange(formatTime(seconds), true);
   }
 
+  useEffect(() => {
+    setHistory((prevHistory) => [...prevHistory, time]);
+    setCurrentIndex((prevIndex) => prevIndex + 1);
+  }, [time]);
+
   return (
     <div className="inline-flex items-stretch justify-start overflow-clip rounded-sm border border-gray-500">
       <input
         className="w-20 px-1 py-1 text-base leading-normal bg-white"
         type="text"
         value={time}
-        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
         onChange={handleChange}
         onBlur={handleBlur}
         placeholder="00:00:00"

--- a/src/content/components/TimeInput.tsx
+++ b/src/content/components/TimeInput.tsx
@@ -1,38 +1,22 @@
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { formatTime, parseTime } from '../lib/time';
-import { useState, useEffect } from 'react';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 import type { Timestamp } from '../../lib/types';
+import { formatTime, parseTime } from '../lib/time';
 
 type Props = {
   time: Timestamp['time'];
+  undo: () => void;
+  redo: () => void;
   onChange: (time: string, isSeek?: boolean) => void;
 };
 
-export function TimeInput({ time, onChange }: Props) {
-  const [history, setHistory] = useState<string[]>([]);
-  const [currentIndex, setCurrentIndex] = useState<number>(-1);
-
-  function handleUndo() {
-    if (currentIndex > 0) {
-      setCurrentIndex((prevIndex) => prevIndex - 1);
-      onChange(history[currentIndex - 1]);
-    }
-  }
-
-  function handleRedo() {
-    if (currentIndex < history.length - 1) {
-      setCurrentIndex((prevIndex) => prevIndex + 1);
-      onChange(history[currentIndex + 1]);
-    }
-  }
-
+export function TimeInput({ time, undo, redo, onChange }: Props) {
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     if (e.ctrlKey && e.key === 'z') {
-      handleUndo();
+      undo();
     }
     if (e.ctrlKey && e.shiftKey && e.key === 'Z') {
-      handleRedo();
+      redo();
     }
   }
 
@@ -53,11 +37,6 @@ export function TimeInput({ time, onChange }: Props) {
 
     onChange(formatTime(seconds), true);
   }
-
-  useEffect(() => {
-    setHistory((prevHistory) => [...prevHistory, time]);
-    setCurrentIndex((prevIndex) => prevIndex + 1);
-  }, [time]);
 
   return (
     <div className="inline-flex items-stretch justify-start overflow-clip rounded-sm border border-gray-500">

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -8,7 +8,7 @@ const ELEMENT_NAME = 'yt-stamper';
 document.addEventListener(
   'keydown',
   (e) => {
-    if (['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab'].includes(e.key)) {
+    if (['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab', 'Control', 'Shift', 'z', 'Z'].includes(e.key)) {
       return;
     }
 


### PR DESCRIPTION
Fixed https://github.com/awyera/yt-stamper/issues/33
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - タイムスタンプ編集時に「元に戻す」と「やり直す」操作を追加し、変更履歴を管理できるようになりました。
  - 入力コンポーネントが、Ctrl+Z および Ctrl+Shift+Z のキーボードショートカットで効率的に動作するよう改善されました。
  - 不要な更新の防止により、操作性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->